### PR TITLE
feat: replace colors function that takes a list of colors to replace

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,25 @@ const animation = Lottie.loadAnimation({
 });
 ```
 
+To replace multiple colors of a Lottie JSON:
+
+```jsx static
+import Lottie from 'lottie-web';
+import { replaceColors } from 'lottie-colorify';
+import SomeAnimation from './SomeAnimation.json';
+
+const animation = Lottie.loadAnimation({
+  container: container.current,
+  animationData: replaceColors(
+    [
+      ['#ff0071', '#cccccc'],
+      ['#f6f6f6', '#000000'],
+    ],
+    LoadingAnimation,
+  ),
+});
+```
+
 To flatten a Lottie JSON and use only one color:
 
 ```jsx static
@@ -81,6 +100,13 @@ replaceColor takes 3 arguments
 1. source color (the color to look for in a Lottie JSON)
 2. target color (the replacement color)
 3. Lottie animation
+
+## replaceColors function
+
+replaceColors takes 2 arguments
+
+1. an array of elements containing a `[sourceColor, targetColor]` pair
+2. Lottie animation
 
 ## flatten function
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,3 +169,9 @@ export const getColors = (lottieObj: any): any => {
   doGet(lottieObj);
   return res;
 };
+
+export const replaceColors = (colorsPair: Array<[string | number[], string | number[]]>, lottie: any): any => {
+  return colorsPair.reduce((computed, [sourceColor, targetColor]) => {
+    return replaceColor(sourceColor, targetColor, computed);
+  }, lottie);
+};


### PR DESCRIPTION
# feat
- Introduces the `replaceColors` function for mutiple lottie colors replacing in 1 shot
- Readme instructions